### PR TITLE
Add negative test cases for threadpool and getfullpath

### DIFF
--- a/test/unittest/unittest_nntrainer_internal.cpp
+++ b/test/unittest/unittest_nntrainer_internal.cpp
@@ -202,6 +202,21 @@ TEST(nntrainer_engine, getFullPath_resolves_relative_and_absolute) {
   EXPECT_EQ(expected, nntrainer::getFullPath(relative_name, absolute));
 }
 
+TEST(nntrainer_engine, getFullPath_empty_path_relative_base_n) {
+  const std::string relative_base = "relative/plugins";
+  EXPECT_EQ(relative_base, nntrainer::getFullPath("", relative_base));
+}
+
+TEST(nntrainer_engine, getFullPath_empty_path_current_dir_base_n) {
+  const std::string base = ".";
+  EXPECT_EQ(base, nntrainer::getFullPath("", base));
+}
+
+TEST(nntrainer_engine, getFullPath_empty_path_trailing_slash_base_n) {
+  const std::string base = "/tmp/nntrainer/";
+  EXPECT_EQ(base, nntrainer::getFullPath("", base));
+}
+
 TEST(nntrainer_thread_pool_manager, select_single_thread_for_small_workload) {
   auto &manager = nntrainer::ThreadPoolManager::Global();
   EXPECT_EQ(1u, manager.select_k_quant_thread_count(1, 1, 1));
@@ -213,6 +228,29 @@ TEST(nntrainer_thread_pool_manager, respect_medium_workload_threshold) {
     std::max<std::size_t>(1U, std::thread::hardware_concurrency());
   const std::size_t expected = std::min<std::size_t>(2U, max_threads);
   EXPECT_EQ(expected, manager.select_k_quant_thread_count(1536, 1536, 1));
+}
+
+TEST(nntrainer_thread_pool_manager, zero_dimension_clamps_to_single_thread_n) {
+  auto &manager = nntrainer::ThreadPoolManager::Global();
+  EXPECT_EQ(1u, manager.select_k_quant_thread_count(0, 2048, 4096));
+}
+
+TEST(nntrainer_thread_pool_manager,
+     near_first_threshold_stays_single_thread_n) {
+  auto &manager = nntrainer::ThreadPoolManager::Global();
+  EXPECT_EQ(1u, manager.select_k_quant_thread_count(1200, 1500, 1));
+}
+
+TEST(nntrainer_thread_pool_manager,
+     second_band_does_not_jump_to_four_threads_n) {
+  auto &manager = nntrainer::ThreadPoolManager::Global();
+  const auto hw_threads =
+    std::max<std::size_t>(1U, std::thread::hardware_concurrency());
+  if (hw_threads < 4U) {
+    GTEST_SKIP() << "Requires >=4 hardware threads to validate regression";
+  }
+
+  EXPECT_EQ(2u, manager.select_k_quant_thread_count(1536, 1800, 1));
 }
 
 /**


### PR DESCRIPTION
## Dependency of the PR

This PR adds negative test cases for existing fixes:
- `2e7da50f714dcf48d0abd9582e7455c8ca92c98f` (threadpool fix)
- `cb3ea503ed9bb14ad7189caf5bd46ae72cdadcb8` (getFullPath fix)

## Commits to be reviewed in this PR

<details><summary>feat: Add negative test cases for threadpool and getFullPath</summary><br />

Add 3 negative test cases for `getFullPath` to prevent regressions related to empty paths and various base combinations, specifically addressing potential `path[0]` access crashes.
Add 3 negative test cases for `ThreadPoolManager::select_k_quant_thread_count` to prevent regressions related to incorrect thread count selection (e.g., 0-dimension input, first threshold boundary, and incorrect jump to 4 threads in the second band).
All new test cases are suffixed with `_n`.

**Self evaluation:**
1. Build test: [X]Passed [ ]Failed [ ]Skipped
2. Run test: [ ]Passed [ ]Failed [X]Skipped

Signed-off-by: Your Name <your_email@example.com>

</details>

### Summary

- Added three negative test cases for `getFullPath` to prevent regressions related to empty paths and various base combinations, specifically addressing potential `path[0]` access crashes.
- Added three negative test cases for `ThreadPoolManager::select_k_quant_thread_count` to prevent regressions related to incorrect thread count selection (e.g., 0-dimension input, first threshold boundary, and incorrect jump to 4 threads).

Signed-off-by: Your Name <your_email@example.com>

---
<a href="https://cursor.com/background-agent?bcId=bc-5f8b4a9f-5cd1-41b9-a379-3bcec3eff280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f8b4a9f-5cd1-41b9-a379-3bcec3eff280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

